### PR TITLE
build jade for staging & protractor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ plugins
 *.DS_Store
 
 app/scripts/configuration.js
+app/templates/**/*.html

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -256,6 +256,20 @@ module.exports = function (grunt) {
           cwd: '<%= yeoman.app %>',
           ext: '.html'
         } ]
+      },
+      ci: {
+        options: {
+          data: {
+            debug: false
+          }
+        },
+        files: [ {
+          expand: true,
+          src: 'templates/**/*.jade',
+          dest: '<%= yeoman.app %>',
+          cwd: '<%= yeoman.app %>',
+          ext: '.html'
+        } ]
       }
     },
     htmlmin: {
@@ -583,6 +597,7 @@ module.exports = function (grunt) {
     'ngconstant:test',
     'autoprefixer',
     'karma:continuous',
+    'jade:ci',
     'protractor:ci'
   ]);
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -246,7 +246,7 @@ module.exports = function (grunt) {
       compile: {
         options: {
           data: {
-            debug: false
+            debug: true
           }
         },
         files: [ {

--- a/Gruntfile.staging.js
+++ b/Gruntfile.staging.js
@@ -5,6 +5,7 @@
     require('time-grunt')(grunt);
 
     grunt.loadNpmTasks('grunt-ng-constant');
+    grunt.loadNpmTasks('grunt-contrib-jade');
 
     grunt.initConfig({
       yeoman: {
@@ -32,10 +33,28 @@
           }
         }
       },
+
+      jade: {
+        compile: {
+          options: {
+            data: {
+              debug: false
+            }
+          },
+          files: [ {
+            expand: true,
+            src: 'templates/**/*.jade',
+            dest: '<%= yeoman.app %>',
+            cwd: '<%= yeoman.app %>',
+            ext: '.html'
+          } ]
+        }
+      }
     });
 
     grunt.registerTask('build', [
-      'ngconstant:staging'
+      'ngconstant:staging',
+      'jade'
     ]);
   };
 })();

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "grunt": "~0.4.5",
     "grunt-cli": "^0.1.13",
     "time-grunt": "~1.0.0",
-    "grunt-ng-constant": "^1.0.0"
+    "grunt-ng-constant": "^1.0.0",
+    "grunt-contrib-jade": "^0.15.0"
   },
   "devDependencies": {
     "chai": "^3.4.1",
@@ -29,7 +30,6 @@
     "grunt-contrib-copy": "~0.7.0",
     "grunt-contrib-cssmin": "~0.11.0",
     "grunt-contrib-htmlmin": "~0.3.0",
-    "grunt-contrib-jade": "^0.15.0",
     "grunt-contrib-jshint": "~0.11.0",
     "grunt-contrib-uglify": "~0.7.0",
     "grunt-contrib-watch": "~0.6.1",


### PR DESCRIPTION
this brings back staging

**important** https://github.com/GrowMoi/moi-front-end/commit/76f0a2d9cd1367593dccef3ef37ea6d5414a166d:
when running protractor, jade will compile html files inside our /templates directory. That’s why we’ll be ignoring all .html files from now on.